### PR TITLE
Make reqwest async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ reqwest = { version = "0.11.3", default-features = false, features = ["blocking"
 serde = { version = "1.0.125", features = ["derive"] }
 chrono = {version = "0.4.19", features = ["serde"] }
 serde_json = "1.0.64"
+async-trait = "0.1.73"


### PR DESCRIPTION
As the blocking client can't be used within an async runtime we've opted to switch to the async reqwest Client. From the reqwest [docs](https://docs.rs/reqwest/latest/reqwest/blocking/index.html):
> the functionality in reqwest::blocking must not be executed within an async runtime, or it will panic when attempting to block