### PR TITLE
feat: extend public api with decide endpoint

### DIFF
--- a/examples/capture.rs
+++ b/examples/capture.rs
@@ -1,13 +1,11 @@
-use posthog_rs::{Client, ClientOptionsBuilder, Event, PublicAPI};
+use posthog_rs::{ClientBuilder, Event, PublicAPI};
 
 async fn run() {
-    let client_options = ClientOptionsBuilder::new()
+    let client = ClientBuilder::new()
+        .set_public_api_key(dotenv::var("POSTHOG_API_KEY").unwrap())
         .set_endpoint(dotenv::var("POSTHOG_URL").unwrap())
-        .set_api_key(dotenv::var("POSTHOG_API_KEY").unwrap())
         .build()
         .unwrap();
-
-    let client = Client::new(client_options);
 
     let mut event = Event::new("test", "1234");
     event.insert_prop("key1", "value1").unwrap();

--- a/examples/capture.rs
+++ b/examples/capture.rs
@@ -1,0 +1,23 @@
+use posthog_rs::{Client, ClientOptionsBuilder, Event, PublicAPI};
+
+async fn run() {
+    let client_options = ClientOptionsBuilder::new()
+        .set_endpoint(dotenv::var("POSTHOG_URL").unwrap())
+        .set_api_key(dotenv::var("POSTHOG_API_KEY").unwrap())
+        .build()
+        .unwrap();
+
+    let client = Client::new(client_options);
+
+    let mut event = Event::new("test", "1234");
+    event.insert_prop("key1", "value1").unwrap();
+    event.insert_prop("key2", vec!["a", "b"]).unwrap();
+
+    let result = client.capture(event).await;
+    println!("result {:?}", result);
+}
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
+    run().await;
+}

--- a/examples/decide_feature_flags.rs
+++ b/examples/decide_feature_flags.rs
@@ -1,17 +1,21 @@
-use posthog_rs::{Client, ClientOptionsBuilder, PublicAPI};
+use posthog_rs::{ClientBuilder, PublicAPI};
 
 async fn run() {
-    let client_options = ClientOptionsBuilder::new()
+    let client = ClientBuilder::new()
         .set_endpoint(dotenv::var("POSTHOG_URL").unwrap())
-        .set_api_key(dotenv::var("POSTHOG_PROJECT_API_KEY").unwrap())
+        .set_public_api_key(dotenv::var("POSTHOG_PROJECT_API_KEY").unwrap())
         .build()
         .unwrap();
 
-    let client = Client::new(client_options);
-    let feature_flags = client.decide("1234".to_owned()).await.unwrap();
+    let feature_flags = client.decide("1234").await;
 
-    for flag in &feature_flags {
-        println!("name: {}, value: {}", flag.0, flag.1);
+    match feature_flags {
+        Ok(flags) => {
+            for flag in &flags {
+                println!("name: {}, value: {}", flag.0, flag.1);
+            }
+        }
+        Err(e) => println!("error: {:?}", e),
     }
 }
 

--- a/examples/decide_feature_flags.rs
+++ b/examples/decide_feature_flags.rs
@@ -1,0 +1,22 @@
+use posthog_rs::{Client, ClientOptionsBuilder, PublicAPI};
+
+async fn run() {
+    let client_options = ClientOptionsBuilder::new()
+        .set_endpoint(dotenv::var("POSTHOG_URL").unwrap())
+        .set_api_key(dotenv::var("POSTHOG_PROJECT_API_KEY").unwrap())
+        .build()
+        .unwrap();
+
+    let client = Client::new(client_options);
+    let feature_flags = client.decide("1234".to_owned()).await.unwrap();
+
+    for flag in &feature_flags {
+        println!("name: {}, value: {}", flag.0, flag.1);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
+    run().await;
+}

--- a/examples/list_feature_flags.rs
+++ b/examples/list_feature_flags.rs
@@ -1,13 +1,11 @@
-use posthog_rs::{Client, ClientOptionsBuilder, FeatureFlagsAPI};
+use posthog_rs::{ClientBuilder, FeatureFlagsAPI};
 
 async fn run() {
-    let client_options = ClientOptionsBuilder::new()
+    let client = ClientBuilder::new()
+        .set_private_api_key(dotenv::var("POSTHOG_API_KEY").unwrap())
         .set_endpoint(dotenv::var("POSTHOG_URL").unwrap())
-        .set_api_key(dotenv::var("POSTHOG_API_KEY").unwrap())
         .build()
         .unwrap();
-
-    let client = Client::new(client_options).private();
 
     let feature_flags = client
         .list_feature_flags(&dotenv::var("POSTHOG_PROJECT_ID").unwrap())

--- a/examples/list_feature_flags.rs
+++ b/examples/list_feature_flags.rs
@@ -7,7 +7,8 @@ async fn run() {
         .build()
         .unwrap();
 
-    let client = Client::new(client_options);
+    let client = Client::new(client_options).private();
+
     let feature_flags = client
         .list_feature_flags(&dotenv::var("POSTHOG_PROJECT_ID").unwrap())
         .await

--- a/src/decide.rs
+++ b/src/decide.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct Decide {
+    pub distinct_id: String,
+}
+
+impl Decide {
+    pub fn new<S: Into<String>>(distinct_id: S) -> Self {
+        Self {
+            distinct_id: distinct_id.into(),
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct InnerDecide {
+    api_key: String,
+    distinct_id: String,
+}
+
+impl InnerDecide {
+    pub(crate) fn new(decide: Decide, api_key: String) -> Self {
+        Self {
+            api_key,
+            distinct_id: decide.distinct_id,
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DecideResponse {
+    pub(crate) feature_flags: HashMap<String, bool>,
+}

--- a/src/decide.rs
+++ b/src/decide.rs
@@ -8,24 +8,9 @@ pub struct Decide {
 }
 
 impl Decide {
-    pub fn new<S: Into<String>>(distinct_id: S) -> Self {
+    pub fn new(distinct_id: &str) -> Self {
         Self {
             distinct_id: distinct_id.into(),
-        }
-    }
-}
-
-#[derive(serde::Serialize)]
-pub(crate) struct InnerDecide {
-    api_key: String,
-    distinct_id: String,
-}
-
-impl InnerDecide {
-    pub(crate) fn new(decide: Decide, api_key: String) -> Self {
-        Self {
-            api_key,
-            distinct_id: decide.distinct_id,
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -32,22 +32,3 @@ impl Event {
         Ok(())
     }
 }
-
-#[derive(Serialize)]
-pub struct InnerEvent {
-    api_key: String,
-    event: String,
-    properties: Properties,
-    timestamp: Option<NaiveDateTime>,
-}
-
-impl InnerEvent {
-    pub fn new(event: Event, api_key: String) -> Self {
-        Self {
-            api_key,
-            event: event.event,
-            properties: event.properties,
-            timestamp: event.timestamp,
-        }
-    }
-}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,8 @@
-use crate::errors::Error;
-use crate::properties::Properties;
 use chrono::NaiveDateTime;
 use serde::Serialize;
+
+use crate::errors::Error;
+use crate::properties::Properties;
 
 #[derive(Serialize, Debug, PartialEq, Eq)]
 pub struct Event {
@@ -29,5 +30,24 @@ impl Event {
             serde_json::to_value(prop).map_err(|e| Error::Serialization(e.to_string()))?;
         let _ = self.properties.props.insert(key.into(), as_json);
         Ok(())
+    }
+}
+
+#[derive(Serialize)]
+pub struct InnerEvent {
+    api_key: String,
+    event: String,
+    properties: Properties,
+    timestamp: Option<NaiveDateTime>,
+}
+
+impl InnerEvent {
+    pub fn new(event: Event, api_key: String) -> Self {
+        Self {
+            api_key,
+            event: event.event,
+            properties: event.properties,
+            timestamp: event.timestamp,
+        }
     }
 }

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use crate::client::PrivateClient;
+use crate::client::{Client, PrivateClient};
 use crate::errors::Error;
 use crate::types::{FeatureKey, ProjectId};
-use crate::Client;
 
 /// API for feature flags as described [here](https://posthog.com/docs/api/feature-flags)
 #[async_trait]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -1,8 +1,10 @@
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::client::PrivateClient;
 use crate::errors::Error;
 use crate::types::{FeatureKey, ProjectId};
 use crate::Client;
-use async_trait::async_trait;
-use serde::Deserialize;
 
 /// API for feature flags as described [here](https://posthog.com/docs/api/feature-flags)
 #[async_trait]
@@ -20,7 +22,7 @@ pub trait FeatureFlagsAPI {
 }
 
 #[async_trait]
-impl FeatureFlagsAPI for Client {
+impl FeatureFlagsAPI for Client<PrivateClient> {
     async fn list_feature_flags(&self, project_id: &ProjectId) -> Result<Vec<FeatureFlag>, Error> {
         let url = format!("/api/projects/{project_id}/feature_flags/");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod public_api;
 /// Data types related to the API
 pub mod types;
 
-pub use client::{Client, ClientOptionsBuilder};
+pub use client::ClientBuilder;
 pub use event::Event;
 pub use feature_flags::FeatureFlagsAPI;
 pub use public_api::PublicAPI;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod client;
 mod config;
+mod decide;
 pub mod errors;
 mod event;
 mod feature_flags;
@@ -12,8 +13,8 @@ mod public_api;
 /// Data types related to the API
 pub mod types;
 
-pub use crate::client::Client;
-pub use crate::client::ClientOptionsBuilder;
-pub use crate::feature_flags::FeatureFlagsAPI;
-pub use crate::types::APIResult;
-pub use types::*;
+pub use client::{Client, ClientOptionsBuilder};
+pub use event::Event;
+pub use feature_flags::FeatureFlagsAPI;
+pub use public_api::PublicAPI;
+pub use types::{APIResult, *};

--- a/src/public_api/mod.rs
+++ b/src/public_api/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 
+use crate::client::PublicClient;
 use crate::decide::{Decide, DecideResponse};
 use crate::errors::Error;
 use crate::event::Event;
@@ -18,11 +19,11 @@ pub trait PublicAPI {
         Ok(())
     }
 
-    async fn decide(&self, user_id: String) -> Result<HashMap<String, bool>, Error>;
+    async fn decide(&self, user_id: &str) -> APIResult<HashMap<String, bool>>;
 }
 
 #[async_trait]
-impl PublicAPI for Client {
+impl PublicAPI for Client<PublicClient> {
     async fn capture(&self, event: Event) -> APIResult<()> {
         let _res = self
             .post_request_with_body("/capture/".into(), event)
@@ -30,7 +31,7 @@ impl PublicAPI for Client {
         Ok(())
     }
 
-    async fn decide(&self, user_id: String) -> Result<HashMap<String, bool>, Error> {
+    async fn decide(&self, user_id: &str) -> APIResult<HashMap<String, bool>> {
         let body = Decide::new(user_id);
         let url = format!("/decide?v=3");
         let res = self.post_request_with_body(url, body).await?;

--- a/src/public_api/mod.rs
+++ b/src/public_api/mod.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 
-use crate::client::PublicClient;
+use crate::client::{Client, PublicClient};
 use crate::decide::{Decide, DecideResponse};
 use crate::errors::Error;
 use crate::event::Event;
 use crate::types::APIResult;
-use crate::Client;
 
 #[async_trait]
 pub trait PublicAPI {

--- a/src/public_api/mod.rs
+++ b/src/public_api/mod.rs
@@ -1,20 +1,43 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::decide::{Decide, DecideResponse};
+use crate::errors::Error;
 use crate::event::Event;
 use crate::types::APIResult;
 use crate::Client;
 
+#[async_trait]
 pub trait PublicAPI {
-    fn capture(&self, event: Event) -> APIResult<()>;
-    fn capture_batch(&self, events: Vec<Event>) -> APIResult<()> {
+    async fn capture(&self, event: Event) -> APIResult<()>;
+    async fn capture_batch(&self, events: Vec<Event>) -> APIResult<()> {
         for event in events {
-            self.capture(event)?;
+            self.capture(event).await?;
         }
         Ok(())
     }
+
+    async fn decide(&self, user_id: String) -> Result<HashMap<String, bool>, Error>;
 }
 
+#[async_trait]
 impl PublicAPI for Client {
-    fn capture(&self, event: Event) -> APIResult<()> {
-        let _res = self.post_request_with_body("/capture/".into(), event);
+    async fn capture(&self, event: Event) -> APIResult<()> {
+        let _res = self
+            .post_request_with_body("/capture/".into(), event)
+            .await?;
         Ok(())
+    }
+
+    async fn decide(&self, user_id: String) -> Result<HashMap<String, bool>, Error> {
+        let body = Decide::new(user_id);
+        let url = format!("/decide?v=3");
+        let res = self.post_request_with_body(url, body).await?;
+        let response: DecideResponse = res
+            .json::<DecideResponse>()
+            .await
+            .map_err(|e| Error::Serialization(e.to_string()))?;
+        Ok(response.feature_flags)
     }
 }


### PR DESCRIPTION
Post request can be sent to the decide endpoint of Posthog API using the user-id to get all its feature-flags. 
An example for the decide request as well as for the event request (same as the one in the original posthog-rs repo) was added. 
Also a little cleanup of the function `post_request_with_body` was done because I don't think we ever tested it before.

SK-3567